### PR TITLE
Add script packaging support to riglets + examples

### DIFF
--- a/lib/genManifest.nix
+++ b/lib/genManifest.nix
@@ -96,9 +96,12 @@ pkgs.writeTextFile {
     - Do not re-read doc files already loaded in your context. If any doc changes after you read it, the **USER is responsible** for notifying you.
 
     **Tools:**
-    - ALL tools from ALL riglets are in `./bin/`—use directly or add to PATH: `export PATH="$PWD/bin:$PATH"`
-    - Tool configuration is pre-merged into `.config/` (standard tool config location). Activate: `export XDG_CONFIG_HOME="$PWD/.config"` before running tools
-    - For unexplained tool behavior, consult `./lib/` or `./share/` (if they exist), but SKILL.md is your primary reference
+    - ALL tools from ALL riglets are in `./bin/`.
+      ALWAYS add to $PATH if not already present: `export PATH="$PWD/bin:$PATH"`.
+      Do NOT just call a tool directly by relative/absolute path: tools in ./bin/ may **call each other by name** and thus need to ALL be in $PATH.
+    - Tool configuration is pre-merged into `.config/` (standard tool config location).
+      Make sure $XDG_CONFIG_HOME is correctly set to this folder (`export XDG_CONFIG_HOME="$PWD/.config"`) **before** running tools.
+    - For unexplained tool behavior, consult `./lib/` or `./share/` (if they exist), but SKILL.md is your **primary reference**
 
     ## Error Cases
 

--- a/lib/mkRiglib.nix
+++ b/lib/mkRiglib.nix
@@ -39,4 +39,13 @@ pkgs: {
         );
     in
     pkgs.runCommand "file-tree" { } (mkFileCommands "" tree);
+
+  # Convert a script path to a package by wrapping it with writeShellScriptBin
+  # Derives the executable name from the script's filename (without extension)
+  wrapScriptPath =
+    scriptPath:
+    let
+      scriptName = baseNameOf (toString scriptPath);
+    in
+    pkgs.writeShellScriptBin scriptName (builtins.readFile scriptPath);
 }

--- a/lib/rigletSchema.nix
+++ b/lib/rigletSchema.nix
@@ -11,7 +11,12 @@ with pkgs.lib;
           options = {
             tools = mkOption {
               description = "List of tools this riglet provides";
-              type = types.listOf types.package;
+              type = types.listOf (
+                types.oneOf [
+                  types.package
+                  types.path
+                ]
+              );
               default = [ ];
             };
 

--- a/riglets/agent-rig/SKILL.md
+++ b/riglets/agent-rig/SKILL.md
@@ -58,7 +58,14 @@ _:
 
   # Riglet definition
   config.riglets.my-riglet = {
-    tools = [ pkgs.tool1 pkgs.tool2 ];
+    # Tools can be:
+    # - Nix packages: pkgs.jujutsu, pkgs.git, etc.
+    # - Script paths: ./scripts/my-script (auto-wrapped as executables)
+    tools = [
+      pkgs.tool1
+      pkgs.tool2
+      ./scripts/helper-script  # Becomes executable "helper-script"
+    ];
 
     # Metadata for discovery and context
     meta = {
@@ -145,6 +152,7 @@ This controls the information/token-count ratio:
 - Example: `jj."config.toml"` → `.config/jj/config.toml`
 - Can use `pkgs.formats.toml`, `.json`, `.yaml` to generate config files from Nix data
 - Can use plain strings for shell scripts or plain text configs
+
 
 ### Helper Functions to Use
 

--- a/riglets/jj-basics/default.nix
+++ b/riglets/jj-basics/default.nix
@@ -23,7 +23,11 @@ _:
   };
 
   config.riglets.jj-basics = {
-    tools = [ pkgs.jujutsu ];
+    tools = [
+      pkgs.jujutsu
+      ./scripts/jj-desc-read
+      ./scripts/jj-desc-edit
+    ];
 
     meta = {
       name = "JJ Basics";
@@ -111,6 +115,34 @@ _:
         # Make edits
         jj new  # Return to tip
         ```
+
+        ### Utility Scripts
+
+        This riglet provides helper scripts for working with change descriptions:
+
+        **Read a revision's description:**
+        ```bash
+        jj-desc-read           # Read current change's description
+        jj-desc-read @-        # Read parent change's description
+        ```
+
+        **Edit description by piping through a command:**
+        ```bash
+        # Replace text in description
+        jj-desc-edit sed 's/foo/bar/g'
+
+        # Convert to uppercase
+        jj-desc-edit awk '{print toupper($0)}'
+
+        # Edit specific revision
+        jj-desc-edit @- sed 's/WIP/DONE/'
+
+        # Advanced regex replacement
+        jj-desc-edit perl -pe 's/bug-(\d+)/issue-$1/g'
+        ```
+
+        These scripts are useful for programmatically modifying change descriptions,
+        which is common when automating workflows or batch-updating descriptions.
       '';
 
       references."revsets.md" = ''

--- a/riglets/jj-basics/scripts/jj-desc-edit
+++ b/riglets/jj-basics/scripts/jj-desc-edit
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Edit a jj revision's description by piping through a command
+# Usage: jj-desc-edit [REVISION] COMMAND [ARGS...]
+#   REVISION defaults to @ (current change)
+#   COMMAND is the command to pipe the description through
+#
+# Examples:
+#   jj-desc-edit sed 's/foo/bar/g'              # Replace foo with bar
+#   jj-desc-edit @ sed 's/WIP/DONE/'            # Edit specific revision
+#   jj-desc-edit awk '{print toupper($0)}'     # Convert to uppercase
+#   jj-desc-edit perl -pe 's/bug-(\d+)/issue-$1/g'  # Regex replacement
+
+set -euo pipefail
+
+# Parse arguments: optional revision, then command
+if [ $# -gt 0 ] && jj show --no-graph "$1" &>/dev/null; then
+  revision="$1"
+  shift
+else
+  revision="@"
+fi
+
+if [ $# -eq 0 ]; then
+  echo "Usage: jj-desc-edit [REVISION] COMMAND [ARGS...]" >&2
+  echo "  Pipes the description through COMMAND and updates it" >&2
+  exit 1
+fi
+
+# Get current description using our jj-desc-read script
+current_desc=$(jj-desc-read "$revision")
+
+# Pipe through the provided command
+new_desc=$(echo "$current_desc" | "$@")
+
+# Update the description using jj describe --stdin
+echo "$new_desc" | jj describe --revision "$revision" --stdin

--- a/riglets/jj-basics/scripts/jj-desc-read
+++ b/riglets/jj-basics/scripts/jj-desc-read
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Read the description of a jj revision
+# Usage: jj-desc-read [REVISION]
+#   REVISION defaults to @ (current change)
+
+set -euo pipefail
+
+revision="${1:-@}"
+
+# Use jj's template feature to extract just the description
+jj log -r "$revision" -T description --no-graph


### PR DESCRIPTION
This enhances the riglet system to better showcase the ability to package
custom scripts alongside tools. Scripts can now be added directly as paths
in the tools field and will be automatically wrapped as executables.

Core changes:
- Enhanced riglet schema to accept both packages and paths in tools field
- Added wrapScript helper to riglib for automatic script wrapping
- Scripts are auto-named from filename (without .sh/.bash extension)
- Updated buildRig to normalize tools (wrap paths as packages)

New jj-basics utilities:
- jj-desc-read: Read a revision's description
- jj-desc-edit: Modify description by piping through arbitrary commands
  (e.g., sed, awk, perl for text transformations)

Documentation updates:
- Added comprehensive "Packaging Scripts with Riglets" section
- Updated example riglet to show script paths in tools
- Included real-world example from jj-basics
- Documented riglib.wrapScript for advanced use cases

The jj-basics riglet now serves as a complete working example of
directory-based riglets with utility scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools can now be specified as either packages or direct script paths for greater flexibility
  * Added utility scripts to read and edit revision descriptions

* **Documentation**
  * New guidance on packaging helper scripts and tools, plus expanded tool-configuration and PATH usage notes

* **Other**
  * Added a helper to wrap script paths as executable packages for seamless inclusion in tool lists

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->